### PR TITLE
Change Disabled to Readonly

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
                     take your data to another computer.
                 </div>
                 <p class="control has-addons">
-                    <input id="user-data-serialized" disabled class="input" type="text" placeholder="Save Data"
+                    <input id="user-data-serialized" readonly class="input" type="text" placeholder="Save Data"
                            value="{{ user_data_serialized }}">
                     <a class="button is-info copy" data-clipboard-target="#user-data-serialized">
                       <span class="icon">


### PR DESCRIPTION
With the user-data-serialized input text field disabled it would not copy to the clipboard.