### PR TITLE
Smaller bundle titles on mobile

### DIFF
--- a/src/components/bundles/BundleItems.vue
+++ b/src/components/bundles/BundleItems.vue
@@ -48,3 +48,15 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+@media (max-width: 480px) {
+  .title {
+    font-size: 1.45rem;
+  }
+
+  .subtitle {
+    font-size: 1rem;
+  }
+}
+</style>


### PR DESCRIPTION
This should fix #97 

There was some issues with the cards on smaller displays that I might take a pass at fixing as well. 