### PR TITLE
Display season and skill names on icon hover

### DIFF
--- a/src/components/SeasonIcon.vue
+++ b/src/components/SeasonIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <span class="icon">
+  <span class="icon" v-bind:data-season="season.id">
     <spring-icon v-if="season.id === 'spring'"/>
     <summer-icon v-if="season.id === 'summer'"/>
     <fall-icon v-if="season.id === 'fall'"/>
@@ -35,6 +35,23 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
+  .icon {
+      position: relative;
+  }
 
+  .icon:hover::after {
+    content: attr(data-season);
+    display: block;
+    position: absolute;
+    bottom: -1.85rem;
+    border-radius: 3px;
+    font-size: .75rem;
+    background-color: #00d1b2;
+    padding: .1rem .3rem;
+    text-transform: capitalize;
+    color: #000;
+    z-index: 100;
+    font-weight: bold;
+  }
 </style>

--- a/src/components/SkillIcon.vue
+++ b/src/components/SkillIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <span class="icon">
+  <span class="icon" v-bind:data-skill="skill.id">
       <farming-icon v-if="skill.id === 'farming'"/>
       <mining-icon v-if="skill.id === 'mining'"/>
       <foraging-icon v-if="skill.id === 'foraging'"/>
@@ -38,6 +38,23 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
+  .icon {
+      position: relative;
+  }
 
+  .icon:hover::after {
+    content: attr(data-skill);
+    display: block;
+    position: absolute;
+    bottom: -1.85rem;
+    border-radius: 3px;
+    font-size: .75rem;
+    background-color: #209cee;
+    padding: .1rem .3rem;
+    text-transform: capitalize;
+    color: #FFF;
+    z-index: 100;
+    font-weight: bold;
+  }
 </style>


### PR DESCRIPTION
This is a pass at #96 

There's some duplication of the styling. We could probably get rid of that by restructuring how the icons and tags interact with each other. 