### PR TITLE
Fixing missing data when loading bundle page.

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -57,7 +57,7 @@ export default new Vuex.Store({
 })
 
 function getById (array, id) {
-  return array.find(x => x.id === id)
+  return array.find(x => x.id == id)
 }
 
 function loadSeasons () {


### PR DESCRIPTION
This should fix #94 

I initially looked into Vuex being the source of the issue but it turned out it was a type issue. For whatever reason, when loading a bundle page directly, the argument comes across as a string but the ID is actually a number so the strict comparison fails (`"19" !== 19`). By allowing JS to coerce the values into the same types, the right value is returned. 

It might be worthwhile to standardize the keys - either make all keys strings or numbers. Then you could put some explicit type checking in place. The only place this could come back to bite you is if someone was to supply `false` for the ID. That would match for id `0`. I could add a guard in there to check if something other than a number or string was provided. 