### PR TITLE
Display 4 cards per row on Search page

### DIFF
--- a/src/components/search/Search.vue
+++ b/src/components/search/Search.vue
@@ -3,7 +3,7 @@
   <search-form v-model="search"></search-form>
   <section class="container">
     <div class="columns is-multiline">
-      <div class="column is-3 is-12-mobile is-6-tablet is-flex" v-for="item in filtered_items" :key="item.id">
+      <div class="column is-3-widescreen is-4-desktop is-12-mobile is-6-tablet is-flex" v-for="item in filtered_items" :key="item.id">
         <item-card :item="item"></item-card>
       </div>
     </div>


### PR DESCRIPTION
This fixes #118. There were some classes missing from the search cards that caused them to display in 2 columns instead of 4 on desktop. 

<img width="1525" alt="Screen Shot 2019-10-26 at 11 44 12 PM" src="https://user-images.githubusercontent.com/654155/67629879-85a61300-f84b-11e9-8cd7-bf60234168a8.png">
