### PR TITLE
Consistent alignment for item card checkboxes

### DIFF
--- a/src/components/item_card/ItemCard.vue
+++ b/src/components/item_card/ItemCard.vue
@@ -125,4 +125,11 @@ export default {
   flex-direction: column;
   justify-content: space-between;
 }
+
+.card-content {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
 </style>


### PR DESCRIPTION
I noticed that the item checkboxes didn't always align depending on the length of the card's content. 

Before

<img width="1446" alt="Screen Shot 2019-10-26 at 11 57 49 PM" src="https://user-images.githubusercontent.com/654155/67629976-7627c980-f84d-11e9-87b1-b73a28766632.png">

After

<img width="1428" alt="Screen Shot 2019-10-27 at 12 03 43 AM" src="https://user-images.githubusercontent.com/654155/67629979-7c1daa80-f84d-11e9-98aa-d946327d7739.png">

