### PR TITLE
Ensure data can be decoded and parsed into JSON before loading

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -195,8 +195,14 @@ export default {
   methods: {
     LoadData: function () {
       if (this.DataToLoad !== '') {
-        this.$store.commit('SetSerializedState', this.DataToLoad)
-        alert('Data Loaded!')
+        try {
+          assertDataIsValid(this.DataToLoad);
+          this.$store.commit('SetSerializedState', this.DataToLoad)
+          alert('Data Loaded!')
+        } catch (err) {
+          console.error('Invalid data string');
+          alert('Error loading data.')
+        }
       }
     },
     ConfirmDelete: function () {
@@ -209,6 +215,10 @@ export default {
       }
     }
   }
+}
+
+function assertDataIsValid(data) {
+  JSON.parse(atob(data));
 }
 </script>
 


### PR DESCRIPTION
This should fix #13 

This ensures that the string can be decoded and parsed into JSON. I wasn't sure how to best check for this: "Be in the same form as the initialized data array (i.e. length = static.bundles.length)". I suppose I could assert that the keys are all valid item IDs?